### PR TITLE
Fix eval command to use ERL_DIST_PORT, consistency with rpc command

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -329,7 +329,7 @@ erl_rpc() {
             fi
 
             if [ "$ERL_DIST_PORT" ]; then
-                result=$("$ERL_RPC" "${DYNAMIC_NAME}" -c "${COOKIE}" -address "${ERL_DIST_PORT}"  -timeout "${RELX_RPC_TIMEOUT}" -a "${command}")
+                result=$("$ERL_RPC" "${DYNAMIC_NAME}" -c "${COOKIE}" -address "${ERL_DIST_PORT}" -timeout "${RELX_RPC_TIMEOUT}" -a "${command}")
             else
                 result=$("$ERL_RPC" "$NAME_TYPE" "$NAME" "${DYNAMIC_NAME}" -c "${COOKIE}" -timeout "${RELX_RPC_TIMEOUT}" -a "${command}")
             fi
@@ -351,7 +351,11 @@ erl_eval() {
         *)
             command=$*
 
-            result=$(echo "${command}" | "$ERL_RPC" "$NAME_TYPE" "$NAME" -R -timeout "${RELX_RPC_TIMEOUT}" -c "${COOKIE}" -e)
+            if [ "$ERL_DIST_PORT" ]; then
+                result=$(echo "${command}" | "$ERL_RPC" "${DYNAMIC_NAME}" -c "${COOKIE}" -address "${ERL_DIST_PORT}" -timeout "${RELX_RPC_TIMEOUT}" -e)
+            else
+                result=$(echo "${command}" | "$ERL_RPC" "$NAME_TYPE" "$NAME" "${DYNAMIC_NAME}" -c "${COOKIE}" -timeout "${RELX_RPC_TIMEOUT}" -e)
+            fi
             code=$?
             if [ $code -eq 0 ]; then
                 echo "$result" | sed 's/^{ok, \(.*\)}$/\1/'


### PR DESCRIPTION
I believe this is intended behaviour:

Quote from https://blog.erlware.org/epmdlessless/ with added emphasis

> These options are used automatically by the release shell script when starting a node, opening a remote shell or interacting with the running node through rpc and **eval**